### PR TITLE
Adding require_once ..vendor/autoload.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,6 +10,8 @@
 */
 namespace Mohiohio\GraphQLWP;
 
+require_once __DIR__."/../../../vendor/autoload.php";
+
 use GraphQL\GraphQL;
 use Mohiohio\WordPress\Router;
 


### PR DESCRIPTION
I couldn't activate the plugin without this change.
Wordpress 4.4.2 and PHP 5.6.x.
