### PR TITLE
Add menu_item_parent field to MenuItem to allow user to create submenus

### DIFF
--- a/Type/Definition/MenuItem.php
+++ b/Type/Definition/MenuItem.php
@@ -41,6 +41,20 @@ class MenuItem extends WPObjectType {
                     return $item->title;
                 }
             ],
+            'menu_order' => [
+                'type' => Type::string(),
+                'description' => 'Item order',
+                'resolve' => function($item) {
+                    return $item->menu_order;
+                }
+            ],
+            'menu_item_parent' => [
+                'type' => Type::string(),
+                'description' => 'Item parent',
+                'resolve' => function($item) {
+                    return $item->menu_item_parent;
+                }
+            ],
             'target' => [
                 'type' => Type::string(),
                 'description' => 'Link target',


### PR DESCRIPTION
We have submenus and need access to the menu_item_parent to create the submenus in the UI.

Let me know if you'd rather me PR off of another branch besides master. 

Thanks for this great project!